### PR TITLE
compile error for "no return bool function" fixed

### DIFF
--- a/Beastdevices_INA3221.cpp
+++ b/Beastdevices_INA3221.cpp
@@ -427,6 +427,8 @@ bool Beastdevices_INA3221::getWarnAlertFlag(ina3221_ch_t channel) {
         return _masken_reg.warn_alert_ch2;
     case INA3221_CH3:
         return _masken_reg.warn_alert_ch3;
+    default:
+        return -1;
     }
 }
 
@@ -438,6 +440,8 @@ bool Beastdevices_INA3221::getCritAlertFlag(ina3221_ch_t channel) {
         return _masken_reg.crit_alert_ch2;
     case INA3221_CH3:
         return _masken_reg.crit_alert_ch3;
+    default:
+        return -1;	    
     }
 }
 


### PR DESCRIPTION
a patch for the "Beastdevices_INA3221.cpp:444:1: error: control reaches end of non-void function [-Werror=return-type]" Error